### PR TITLE
parse fancy declarations:

### DIFF
--- a/src/flotate.js
+++ b/src/flotate.js
@@ -28,9 +28,10 @@ function jsToAst(jsSource, opts) {
 
 function commentToFlowType(flotateString) { // => flowTypeString
     return flotateString
-        .replace(/\/\*flow-ignore-begin\*\//, '/*') // /*flow-ignore-begin*/        => /*
-        .replace(/\/\*flow-ignore-end\*\//, '*/')   // /*flow-ignore-end*/          => */
-        .replace(/\/\*::([\s\S]+?)\*\//, '$1');     // /*:: type BarBaz = number */ => type BarBaz = number
+        .replace(/\/\*flow-ignore-begin\*\//, '/*')       // /*flow-ignore-begin*/        => /*
+        .replace(/\/\*flow-ignore-end\*\//, '*/')         // /*flow-ignore-end*/          => */
+        .replace(/\/\*::([\s\S]+?)\*\//, '$1')            // /*:: type BarBaz = number */ => type BarBaz = number
+        .replace(/\/\*flow-include([\s\S]+?)\*\//, '$1'); // /*flow-include type BarBaz = number */ => type BarBaz = number
 }
 
 function processFunctionNode(node, body) {

--- a/src/flotate.js
+++ b/src/flotate.js
@@ -41,6 +41,22 @@ function processFunctionNode(node, body) {
     var header = source.substr(0, pos);
     var body = source.substr(pos);
 
+    // First check if there is *fancy* type annotation in the leading comment
+    var leadingComments = (node.id || {}).leadingComments || [];
+    for (var i = 0; i < leadingComments.length; i++) {
+        // /* @: (x: String, y: number): boolean
+        var m = leadingComments[i].source().match(/\/\*\s*@:([\s\S]+?)\*\//);
+
+        if (m) {
+            // replace everything after first brace
+            header = header.replace(/\([\s\S]*$/, m[1]);
+            node.update(header + body);
+            leadingComments[i].update("");
+            return;
+        }
+    }
+
+    // Otherwise replace in-parameter-list annotation
     header = header
         .replace(/\/\*:([\s\S]+?)\*\//g, ': $1');    // /*: FooBar */ => : FooBar
 

--- a/src/flotate.js
+++ b/src/flotate.js
@@ -44,8 +44,10 @@ function processFunctionNode(node, body) {
     // First check if there is *fancy* type annotation in the leading comment
     var leadingComments = (node.id || {}).leadingComments || [];
     for (var i = 0; i < leadingComments.length; i++) {
-        // /* @: (x: String, y: number): boolean
-        var m = leadingComments[i].source().match(/\/\*\s*@:([\s\S]+?)\*\//);
+        // The same `:` prefix!
+        // There is no ambiguity, as intances are in different contexts
+        // /* : (x: String, y: number): boolean
+        var m = leadingComments[i].source().match(/\/\*\s*:([\s\S]+?)\*\//);
 
         if (m) {
             // replace everything after first brace

--- a/src/flotate.js
+++ b/src/flotate.js
@@ -28,10 +28,10 @@ function jsToAst(jsSource, opts) {
 
 function commentToFlowType(flotateString) { // => flowTypeString
     return flotateString
-        .replace(/\/\*flow-ignore-begin\*\//, '/*')       // /*flow-ignore-begin*/        => /*
-        .replace(/\/\*flow-ignore-end\*\//, '*/')         // /*flow-ignore-end*/          => */
-        .replace(/\/\*::([\s\S]+?)\*\//, '$1')            // /*:: type BarBaz = number */ => type BarBaz = number
-        .replace(/\/\*flow-include([\s\S]+?)\*\//, '$1'); // /*flow-include type BarBaz = number */ => type BarBaz = number
+        .replace(/\/\*\s*flow-ignore-begin\*\//, '/*')       // /* flow-ignore-begin*/        => /*
+        .replace(/\/\*\s*flow-ignore-end\*\//, '*/')         // /* flow-ignore-end*/          => */
+        .replace(/\/\*\s*::([\s\S]+?)\*\//, '$1')            // /* :: type BarBaz = number */ => type BarBaz = number
+        .replace(/\/\*\s*flow-include([\s\S]+?)\*\//, '$1'); // /* flow-include type BarBaz = number */ => type BarBaz = number
 }
 
 function processFunctionNode(node, body) {
@@ -61,7 +61,7 @@ function processFunctionNode(node, body) {
 
     // Otherwise replace in-parameter-list annotation
     header = header
-        .replace(/\/\*:([\s\S]+?)\*\//g, ': $1');    // /*: FooBar */ => : FooBar
+        .replace(/\/\*\s*:([\s\S]+?)\*\//g, ': $1');    // /* : FooBar */ => : FooBar
 
     node.update(header + body);
 }

--- a/test/fixtures/fancy-annotation.js
+++ b/test/fixtures/fancy-annotation.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-/* @: (x: string, y: number): boolean */
+/* : (x: string, y: number): boolean */
 function foo(x, y) {
     return x.length * y === 5;
 }

--- a/test/fixtures/fancy-annotation.js
+++ b/test/fixtures/fancy-annotation.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+/* @: (x: string, y: number): boolean */
+function foo(x, y) {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/fancy-annotation.ts
+++ b/test/fixtures/fancy-annotation.ts
@@ -1,0 +1,7 @@
+/* @flow */
+
+
+function foo (x: string, y: number): boolean {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/function-argument-and-return-types-ws.js
+++ b/test/fixtures/function-argument-and-return-types-ws.js
@@ -1,0 +1,5 @@
+/* @flow */
+function foo(x /* : string */, y /* : number */) /* : boolean */ {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/function-argument-and-return-types-ws.ts
+++ b/test/fixtures/function-argument-and-return-types-ws.ts
@@ -1,0 +1,5 @@
+/* @flow */
+function foo(x :  string , y :  number ) :  boolean  {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/ignores-ws.js
+++ b/test/fixtures/ignores-ws.js
@@ -1,0 +1,7 @@
+/* @flow */
+function foo() {
+    /* flow-ignore-begin*/
+    this.doingIllegalThings();
+    /* flow-ignore-end*/
+    alert('Yay!');
+}

--- a/test/fixtures/ignores-ws.ts
+++ b/test/fixtures/ignores-ws.ts
@@ -1,0 +1,7 @@
+/* @flow */
+function foo() {
+    /*
+    this.doingIllegalThings();
+    */
+    alert('Yay!');
+}

--- a/test/fixtures/include-ws.js
+++ b/test/fixtures/include-ws.js
@@ -1,0 +1,6 @@
+/* @flow */
+/* flow-include type FooBar = { id: number } */
+function foo(x /*: FooBar */) /*: boolean */ {
+    return x.id * 5 === 5;
+}
+foo({ id: 123 });

--- a/test/fixtures/include-ws.ts
+++ b/test/fixtures/include-ws.ts
@@ -1,0 +1,6 @@
+/* @flow */
+ type FooBar = { id: number } 
+function foo(x :  FooBar ) :  boolean  {
+    return x.id * 5 === 5;
+}
+foo({ id: 123 });

--- a/test/fixtures/include.js
+++ b/test/fixtures/include.js
@@ -1,0 +1,6 @@
+/* @flow */
+/*flow-include type FooBar = { id: number } */
+function foo(x /*: FooBar */) /*: boolean */ {
+    return x.id * 5 === 5;
+}
+foo({ id: 123 });

--- a/test/fixtures/include.ts
+++ b/test/fixtures/include.ts
@@ -1,0 +1,6 @@
+/* @flow */
+ type FooBar = { id: number } 
+function foo(x :  FooBar ) :  boolean  {
+    return x.id * 5 === 5;
+}
+foo({ id: 123 });

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -40,14 +40,17 @@ describe('flotate', function() {
 
         itFixture('function-argument-types-only');
         itFixture('function-argument-and-return-types');
+        itFixture('function-argument-and-return-types-ws');
         itFixture('transform-stability');
         itFixture('return-module-object');
         itFixture('typedefs');
         itFixture('classes');
         itFixture('ignores');
+        itFixture('ignores-ws');
         itFixture('whitespace');
         itFixture('fancy-annotation');
         itFixture('include');
+        itFixture('include-ws');
 
     });
 

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -46,6 +46,7 @@ describe('flotate', function() {
         itFixture('classes');
         itFixture('ignores');
         itFixture('whitespace');
+        itFixture('fancy-annotation');
 
     });
 

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -47,6 +47,7 @@ describe('flotate', function() {
         itFixture('ignores');
         itFixture('whitespace');
         itFixture('fancy-annotation');
+        itFixture('include');
 
     });
 

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -29,69 +29,23 @@ describe('flotate', function() {
     });
 
     describe('jsToFlow()', function() {
+        function itFixture(fixture) {
+            it(fixture, function() {
+                var input = getFixture(fixture + ".js");
+                var expectedOutput = getFixture(fixture + '.ts');
+                var actualOutput = flotate.jsToFlow(input);
+                actualOutput.should.equal(expectedOutput);
+            });
+        }
 
-        it('function-return-type-only', function() {
-            var input = getFixture('function-return-type-only.js');
-            var expectedOutput = getFixture('function-return-type-only.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('function-argument-types-only', function() {
-            var input = getFixture('function-argument-types-only.js');
-            var expectedOutput = getFixture('function-argument-types-only.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('function-argument-and-return-types', function() {
-            var input = getFixture('function-argument-and-return-types.js');
-            var expectedOutput = getFixture('function-argument-and-return-types.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('transform-stability', function() {
-            var input = getFixture('transform-stability.js');
-            var expectedOutput = getFixture('transform-stability.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('return-module-object', function() {
-            var input = getFixture('return-module-object.js');
-            var expectedOutput = getFixture('return-module-object.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('typedefs', function() {
-            var input = getFixture('typedefs.js');
-            var expectedOutput = getFixture('typedefs.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('classes', function() {
-            var input = getFixture('classes.js');
-            var expectedOutput = getFixture('classes.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('ignores', function() {
-            var input = getFixture('ignores.js');
-            var expectedOutput = getFixture('ignores.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
-
-        it('whitespace', function() {
-            var input = getFixture('whitespace.js');
-            var expectedOutput = getFixture('whitespace.ts');
-            var actualOutput = flotate.jsToFlow(input);
-            actualOutput.should.equal(expectedOutput);
-        });
+        itFixture('function-argument-types-only');
+        itFixture('function-argument-and-return-types');
+        itFixture('transform-stability');
+        itFixture('return-module-object');
+        itFixture('typedefs');
+        itFixture('classes');
+        itFixture('ignores');
+        itFixture('whitespace');
 
     });
 


### PR DESCRIPTION
``` js
/* @: (x: string, y: number): boolean */
function foo(x, y) {
    return x.length * y === 5;
}
```

into

``` js
function foo (x: string, y: number): boolean {
    return x.length * y === 5;
}
```

I'd rather repeat a bit, than write ugly `/* : types */` inline.
