### PR TITLE
Fix a bug related to transforming directories ending with .js

### DIFF
--- a/src/flotate.js
+++ b/src/flotate.js
@@ -45,6 +45,9 @@ function jsToFlow(jsSource) {
 exports.jsToFlow = jsToFlow;
 
 function transformFileInPlace(filePath) {
+    if (fs.statSync(filePath).isDirectory()) {
+        return; // directories can't be transformed
+    }
     if (ELIGIBLE_FILE_EXTS.indexOf(path.extname(filePath)) === -1) {
         return; // uninteresting file type
     }

--- a/test/fixtures/flowcheck/.flowconfig
+++ b/test/fixtures/flowcheck/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/test/fixtures/flowcheck/dir-trap.js/div.js
+++ b/test/fixtures/flowcheck/dir-trap.js/div.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+function operation(a /*:number */,b /*:number */) /*: number */ {
+	return a / b;
+}
+
+
+module.exports = { operation: operation };

--- a/test/fixtures/flowcheck/main.js
+++ b/test/fixtures/flowcheck/main.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+var div = require('./dir-trap.js/div.js');
+
+
+div.operation('a', 'b');

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -95,4 +95,12 @@ describe('flotate', function() {
 
     });
 
+    describe('flowCheck()', function() {
+        it('doesn\'t try to transform directories', function() {
+            (function() {
+                flotate.flowCheck(__dirname + '/../fixtures/flowcheck/');
+            }).should.not.throw();
+        });
+    });
+
 });


### PR DESCRIPTION
Flotate currently has a bug related to directories ending with .js or other whitelisted file extensions. Apparently  `wrench.readdirSyncRecursive` returns also directories in addition to files. In most cases, this is not a problem since flotate filters all resources by file extension. However, if the directory name contains ".js", flotate crashes with `Error: EISDIR, illegal operation on a directory`. I fixed this by explicitly checking whether the resource is a directory before trying to transform it.

Steps to reproduce the bug:
1. create a project with valid flow config
2. in the project directory, create a _directory_ with a name example.js
3. run flotate with `flotate check`

Any idea how to write a test for this?
