### PR TITLE
Return-type annotations still broken in JSX

### DIFF
--- a/test/fixtures/react-jsx-class.js
+++ b/test/fixtures/react-jsx-class.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+module.exports = React.createClass({
+  render() /*: ReactElement */ {
+    return (
+      <section className="foobar">
+        ...
+      </section>
+    );
+  }
+});

--- a/test/fixtures/react-jsx-class.ts
+++ b/test/fixtures/react-jsx-class.ts
@@ -1,0 +1,11 @@
+/* @flow */
+
+module.exports = React.createClass({
+  render() : ReactElement  {
+    return (
+      <section className="foobar">
+        ...
+      </section>
+    );
+  }
+});

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -52,6 +52,7 @@ describe('flotate', function() {
         itFixture('fancy-annotation');
         itFixture('include');
         itFixture('include-ws');
+        itFixture('react-jsx-class');
 
     });
 


### PR DESCRIPTION
Not sure if it's exactly JSX, but something's still off; added a failing test to document this.
