### PR TITLE
implement support for extracting type comment from lvalue of assignment expression

### DIFF
--- a/src/flotate.js
+++ b/src/flotate.js
@@ -9,7 +9,7 @@ var spawn = require('child_process').spawn;
 var TEMP_DIR_NAME = 'flotate';
 var EXCLUDED_PATHS = /(\.git)/;
 var ELIGIBLE_FILE_EXTS = [ '.js', '.jsx' ];
-var TRIGGER_PATTERN = /^\/\* *@flow/;
+var TRIGGER_PATTERN = /^[\r\n\s]*\/\* *@flow/;
 var ASSUMED_ENCODING = 'utf8';
 var FLOW_CONFIG_FILE = '.flowconfig';
 

--- a/src/flotate.js
+++ b/src/flotate.js
@@ -44,6 +44,17 @@ function processFunctionNode(node, body) {
 
     // First check if there is *fancy* type annotation in the leading comment
     var leadingComments = (node.id || {}).leadingComments || [];
+    // If there is no leading comment, see whether we are a function expression assignment
+    // or variable declaration, and if so, inherit the leading comment of the lvalue
+    if (leadingComments.length == 0) {
+      if (node.parent) {
+        if (node.parent.type == 'AssignmentExpression') {
+          leadingComments = node.parent.left.leadingComments || [];
+        } else if (node.parent.type == 'VariableDeclarator') {
+          leadingComments = node.parent.id.leadingComments || [];
+        }
+      }
+    }
     for (var i = 0; i < leadingComments.length; i++) {
         // The same `:` prefix!
         // There is no ambiguity, as instances are in different contexts

--- a/test/fixtures/function-expression-assignment.js
+++ b/test/fixtures/function-expression-assignment.js
@@ -1,0 +1,7 @@
+/* @flow */
+var foo;
+/*: (x: string, y: number): boolean */
+foo = function(x, y) {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/function-expression-assignment.ts
+++ b/test/fixtures/function-expression-assignment.ts
@@ -1,0 +1,7 @@
+/* @flow */
+var foo;
+
+foo = function (x: string, y: number): boolean {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/function-expression-method.js
+++ b/test/fixtures/function-expression-method.js
@@ -1,0 +1,21 @@
+/* @flow */
+var Foo;
+Foo = (function() {
+  function Foo() {}
+
+  /*: (x: string, y: number): boolean */
+
+  Foo.prototype.instanceMember = function(x, y) {
+      return x.length * y === 5;
+  };
+
+  /*: (x: string, y: number): boolean */
+
+  Foo.classMember = function(x, y) {
+      return x.length * y === 5;
+  };
+});
+
+var f = new Foo();
+f.member('Hello', 42);
+Foo.classMember('Hello', 42);

--- a/test/fixtures/function-expression-method.ts
+++ b/test/fixtures/function-expression-method.ts
@@ -1,0 +1,21 @@
+/* @flow */
+var Foo;
+Foo = (function() {
+  function Foo() {}
+
+  
+
+  Foo.prototype.instanceMember = function (x: string, y: number): boolean {
+      return x.length * y === 5;
+  };
+
+  
+
+  Foo.classMember = function (x: string, y: number): boolean {
+      return x.length * y === 5;
+  };
+});
+
+var f = new Foo();
+f.member('Hello', 42);
+Foo.classMember('Hello', 42);

--- a/test/fixtures/function-expression-var-declaration.js
+++ b/test/fixtures/function-expression-var-declaration.js
@@ -1,0 +1,6 @@
+/* @flow */
+/*: (x: string, y: number): boolean */
+var foo = function(x, y) {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/fixtures/function-expression-var-declaration.ts
+++ b/test/fixtures/function-expression-var-declaration.ts
@@ -1,0 +1,6 @@
+/* @flow */
+
+var foo = function (x: string, y: number): boolean {
+    return x.length * y === 5;
+}
+foo('Hello', 42);

--- a/test/spec/flotate.spec.js
+++ b/test/spec/flotate.spec.js
@@ -42,6 +42,9 @@ describe('flotate', function() {
         itFixture('function-argument-types-only');
         itFixture('function-argument-and-return-types');
         itFixture('function-argument-and-return-types-ws');
+        itFixture('function-expression-var-declaration');
+        itFixture('function-expression-assignment');
+        itFixture('function-expression-method');
         itFixture('transform-stability');
         itFixture('return-module-object');
         itFixture('typedefs');


### PR DESCRIPTION
See #7

This patch allows inheriting the comment of the lvalue if the function expression is part of an assignment expression.  This allows comments of the following form, which in turn results in support for classes generated by CoffeeScript and annotated with CoffeeScript block comments.

``` coffeescript
### @flow ###
class Foo
  ###: (x: string, y: number): boolean ###
  foo: (x, y) ->
    x.length * y == 5

new Foo().foo('Hello', 42)
new Foo().foo(100, 42)
```

``` javascript
/* @flow */
var Foo;

Foo = (function() {
  function Foo() {}


  /*: (x: string, y: number): boolean */

  Foo.prototype.foo = function(x, y) {
    return x.length * y === 5;
  };

  return Foo;

})();

new Foo().foo('Hello', 42);

new Foo().foo(100, 42);
```
